### PR TITLE
Fix case-insensitive module require statement in ZeParser.js

### DIFF
--- a/ZeParser.js
+++ b/ZeParser.js
@@ -1,5 +1,5 @@
 if (typeof exports !== 'undefined') {
-	var Tokenizer = require('./tokenizer').Tokenizer;
+	var Tokenizer = require('./Tokenizer').Tokenizer;
 	exports.ZeParser = ZeParser;
 }
 


### PR DESCRIPTION
This is required for case sensitive file systems like most linux setups use.
