### PR TITLE
Removed pointless index.js and ignoring big test files for npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+*.html
+tests.js

--- a/index.js
+++ b/index.js
@@ -1,1 +1,0 @@
-exports.ZeParser = require('./ZeParser').ZeParser;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "type": "git",
     "url": "git://github.com/qfox/ZeParser.git"
   },
-  "main": "./index",
+  "main": "./ZeParser",
   "engines": {
     "node": "*"
   },


### PR DESCRIPTION
Removed the pointless index.js, I assume that it was added for Node.js. In the package.json you can just specify the modules entry point, so using ZeParser.js directly reduces a pointless require statement.

In addition to that I have added all html files and the tests.js to .npmignore to reduce the filesize of the npm package.
