### PR TITLE
Add license to package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,5 +13,6 @@
     "node": "*"
   },
   "dependencies": {},
-  "devDependencies": {}
+  "devDependencies": {},
+  "license": "MIT"
 }


### PR DESCRIPTION
Fix to allow tools such as [nlf](https://github.com/iandotkelly/nlf) to correctly identify license type.
