### PR TITLE
Updated .npmignore to exclude benchmarks

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 *.html
 tests.js
+benchmark.html


### PR DESCRIPTION
The `benchmark.html` is too large to be bundled with the NPM package, especially when this package is used by other packages as a dependency.
